### PR TITLE
Fix for 'replace' param in modified method signature

### DIFF
--- a/lib/sdb/right_sdb_interface.rb
+++ b/lib/sdb/right_sdb_interface.rb
@@ -351,7 +351,6 @@ module RightAws
     def put_attributes(domain_name, item_name, attributes, replace = [], expected_attr = {})
       params = { 'DomainName' => domain_name,
                  'ItemName'   => item_name }.merge(pack_attributes(attributes, replace, false, expected_attr))
-      puts params.inspect
       link = generate_request("PutAttributes", params)
       request_info( link, QSdbSimpleParser.new )
     rescue Exception


### PR DESCRIPTION
Handle the case where some attributes are to be replaced and other are to be appended. Relevant spec can be found in tapjoyserver's spec/lib/simpledb_resource_spec.rb:70 :

```
it 'handles adding and replacing attrs in one save operation' do
  attrs = {}

  10.times do |i|
    @model.put("#{i}", 'value')
    attrs["#{i}"] = ['value']
  end

  @model.save!

  load_model

  @model.put('1', 'replaced_value')
  @model.put('2', 'value2', {:replace => false})
  attrs['1'] = ['replaced_value']
  attrs['2'].push('value2')
  @model.save!

  load_model
  @model.attributes.delete('updated-at')
  @model.attributes.should == attrs
end
```
